### PR TITLE
Auto merge script

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,7 @@
 {
   "extends": "springworks/babel",
   "rules": {
+    "no-console": 0,
+    "no-process-exit": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
 # gitbot
+
+Module containing convenience scripts against GitHub
+
+## Environment variables
+
+- `GITBOT_GITHUB_TOKEN`: Access token against GitHub which needs to have read/write permissions on that repository
+
+## Usage
+
+Install module globally:
+
+```
+npm install -g @springworks/gitbot
+```
+
+```bash
+  Usage: gitbot [options] [command]
+
+  Commands:
+
+    auto-merge   merge pull request and delete branch
+    help [cmd]   display help for [cmd]
+
+  Options:
+
+    -h, --help  output usage information
+```
+
+### auto-merge
+Merges pull request and deletes branch.
+
+**Usage**
+```
+  Usage: gitbot-auto-merge [options]
+
+  Options:
+
+    -h, --help                                       output usage information
+    -O, --owner <owner>                              repository owner
+    -R, --repository-name <repository name>          repository name
+    -N, --pull-request-number <pull request number>  pull request number
+```
+
+**Example**
+
+```
+$ gitbot auto-merge -O john-doe -R awesome-repo -N 40
+```
+
+## Notes
+
+This module uses the [semantic-release](https://github.com/semantic-release/semantic-release) automated package publishing. 
+Which means that the commit messages are required to look in a certain [way](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md).
+
+To ensure this pattern is enforced, we use [pre-git](https://github.com/bahmutov/pre-git) which installs a `commit-msg` hook.
+Please read and understand what the `types` mean and use them properly when committing and contributing.
+
+The `commit-msg` hook needs to know about your installed `node` which means that if you use third party application when committing, like [Tower](http://www.git-tower.com/), that application needs to know your PATH environment.
+There are probably a lot of ways to solve this, but one that works is to open the application from the terminal: `open /Applications/Tower.app`.
+
+## Contributing
+1. Create new branch and commit changes with corresponding tests
+2. Make a PR
+3. :pray: :clap:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "gitbot",
   "description": "Module containing convenience scripts against GitHub",
-  "main": "lib/index.js",
   "scripts": {
     "lint": "eslint --cache .",
     "test": "NODE_ENV=test istanbul cover _mocha",
@@ -12,6 +11,9 @@
     "prepublish": "npm run build",
     "commit": "commit-wizard",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "bin": {
+    "gitbot": "./lib/bin/gitbot.js"
   },
   "repository": {
     "type": "git",
@@ -44,7 +46,9 @@
     "semantic-release": "4.3.5"
   },
   "dependencies": {
+    "@springworks/input-validator": "4.0.8",
     "babel-runtime": "6.5.0",
+    "commander": "2.9.0",
     "github": "0.2.4"
   },
   "config": {

--- a/src/bin/gitbot-auto-merge.js
+++ b/src/bin/gitbot-auto-merge.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const program = require('commander');
+const auto_merge = require('../commands/auto-merge');
+
+program
+    .option('-O, --owner <owner>', 'repository owner')
+    .option('-R, --repository-name <repository name>', 'repository name')
+    .option('-N, --pull-request-number <pull request number>', 'pull request number')
+    .parse(process.argv);
+
+auto_merge.run(process, {
+      repo_owner: program.owner,
+      repo_name: program.repositoryName,
+      pull_request_number: program.pullRequestNumber,
+    })
+    .then(() => {
+      console.log('Done!');
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error('Error auto-merging pull request', err);
+      process.exit(1);
+    });

--- a/src/bin/gitbot.js
+++ b/src/bin/gitbot.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+require('babel-core/register');
+
+const program = require('commander');
+
+program
+    .command('auto-merge', 'merge pull request and delete branch')
+    .parse(process.argv);

--- a/src/commands/auto-merge.js
+++ b/src/commands/auto-merge.js
@@ -1,0 +1,37 @@
+const joi = require('@springworks/input-validator').joi;
+const validateSchema = require('@springworks/input-validator').validateSchema;
+const git_wrapper = require('../git/git-service');
+
+const internals = {};
+
+const auto_merge_validation_schema = joi.object().required().keys({
+  repo_owner: joi.string().required().trim(),
+  repo_name: joi.string().required().trim(),
+  pull_request_number: joi.number().required(),
+});
+
+exports.run = (process, params) => {
+  const github_token = process.env.GITBOT_GITHUB_TOKEN;
+  return Promise.resolve(params)
+      .then(internals.validateParams)
+      .then(valid_params => {
+        const git_service = git_wrapper.create(github_token);
+        return internals.autoMerge(git_service, valid_params.repo_owner, valid_params.repo_name, valid_params.pull_request_number);
+      });
+};
+
+internals.validateParams = params => {
+  try {
+    return validateSchema(params, auto_merge_validation_schema);
+  }
+  catch (err) {
+    console.error('validateParams failed: %j', err);
+    return Promise.reject(err);
+  }
+};
+
+internals.autoMerge = (git_service, repo_owner, repo_name, pull_request_number) => {
+  return git_service.getPullRequest(repo_owner, repo_name, pull_request_number)
+      .then(pull_request => git_service.mergePullRequest(repo_owner, repo_name, pull_request_number)
+          .then(() => git_service.deleteBranch(repo_owner, repo_name, pull_request.head.ref)));
+};

--- a/src/git/git-service.js
+++ b/src/git/git-service.js
@@ -1,0 +1,79 @@
+const GitHubApi = require('github');
+
+const internals = {};
+
+exports.create = github_token => {
+  const github_client = internals.getAuthenticatedGitHubClient(github_token);
+  return {
+    getPullRequest: internals.getPullRequest.bind(null, github_client),
+    mergePullRequest: internals.mergePullRequest.bind(null, github_client),
+    deleteBranch: internals.deleteBranch.bind(null, github_client),
+  };
+};
+
+internals.getAuthenticatedGitHubClient = github_token => {
+  const github_client = new GitHubApi({
+    version: '3.0.0',
+  });
+
+  github_client.authenticate({
+    type: 'token',
+    token: github_token,
+  });
+
+  return github_client;
+};
+
+internals.getPullRequest = (github, repo_owner, repo_name, pull_request_number) => {
+  return new Promise((resolve, reject) => {
+    github.pullRequests.get({
+      user: repo_owner,
+      repo: repo_name,
+      number: pull_request_number,
+    }, (err, res) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(res);
+    });
+  });
+};
+
+internals.mergePullRequest = (github, repo_owner, repo_name, pull_request_number) => {
+  return new Promise((resolve, reject) => {
+    github.pullRequests.merge({
+      user: repo_owner,
+      repo: repo_name,
+      number: pull_request_number,
+    }, (err, res) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(res);
+    });
+  });
+};
+
+internals.deleteBranch = (github, repo_owner, repo_name, branch_name) => {
+  const ref = `heads/${branch_name}`;
+  return new Promise((resolve, reject) => {
+    console.log(branch_name);
+    github.gitdata.deleteReference({
+      user: repo_owner,
+      repo: repo_name,
+      ref: ref,
+    }, (err, res) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(res);
+    });
+  });
+};
+
+if (process.env.NODE_ENV === 'test') {
+  exports.internals = internals;
+}

--- a/test/commands/auto-merge-test.js
+++ b/test/commands/auto-merge-test.js
@@ -1,0 +1,145 @@
+const auto_merge = require('../../src/commands/auto-merge');
+const git_wrapper = require('../../src/git/git-service');
+const autorestoredSandbox = require('@springworks/test-harness/autorestored-sandbox');
+
+const internals = {};
+
+describe('test/commands/auto-merge-test.js', () => {
+  const sinon_sandbox = autorestoredSandbox();
+  console.error = sinon.stub();
+
+  describe('run', () => {
+    let git_service;
+    let mock_process;
+    let params;
+
+    beforeEach(() => {
+      mock_process = internals.createMockProcess();
+      params = internals.createValidParams();
+    });
+
+    describe('with valid params', () => {
+
+      describe('when everything goes well', () => {
+
+        beforeEach(() => {
+          git_service = internals.mockHappyGitService();
+          sinon_sandbox.stub(git_wrapper, 'create').returns(git_service);
+        });
+
+        it('should resolve without errors', () => {
+          return auto_merge.run(mock_process, params).should.be.fulfilled();
+        });
+
+        it('should call getPullRequest with correct arguments', () => {
+          return auto_merge.run(mock_process, params).then(() => {
+            git_service.getPullRequest.should.be.calledWith(params.repo_owner, params.repo_name, params.pull_request_number);
+          });
+        });
+
+        it('should call mergePullRequest with correct arguments', () => {
+          return auto_merge.run(mock_process, params).then(() => {
+            git_service.mergePullRequest.should.be.calledWith(params.repo_owner, params.repo_name, params.pull_request_number);
+          });
+        });
+
+        it('should call deleteBranch with correct arguments', () => {
+          return auto_merge.run(mock_process, params).then(() => {
+            git_service.deleteBranch.should.be.calledWith(params.repo_owner, params.repo_name, 'feature/super-feature');
+          });
+        });
+
+      });
+
+      describe('when getting pull request fails', () => {
+
+        beforeEach(() => {
+          git_service = internals.mockSadGitService();
+          sinon_sandbox.stub(git_wrapper, 'create').returns(git_service);
+        });
+
+        it('should resolve with mock error', () => {
+          return auto_merge.run(mock_process, params).should.be.rejectedWith({
+            message: 'Mock error',
+          });
+        });
+
+        it('should not call mergePullRequest', () => {
+          return auto_merge.run(mock_process, params).catch(() => {
+            git_service.mergePullRequest.should.not.be.called();
+          });
+        });
+
+        it('should not call deleteBranch', () => {
+          return auto_merge.run(mock_process, params).catch(() => {
+            git_service.deleteBranch.should.not.be.called();
+          });
+        });
+
+      });
+
+    });
+
+    describe('with invalid params', () => {
+      const required_params = [
+        'repo_owner',
+        'repo_name',
+        'pull_request_number',
+      ];
+
+      required_params.forEach(required_param => {
+
+        describe(`when missing param: ${required_param}`, () => {
+
+          beforeEach(() => {
+            delete params[required_param];
+          });
+
+          it('should throw validation error', () => {
+            return auto_merge.run(mock_process, params).should.be.rejectedWith({
+              code: 422,
+              message: 'Validation Failed',
+            });
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+});
+
+internals.mockHappyGitService = () => {
+  return {
+    getPullRequest: sinon.stub().returns(Promise.resolve({ head: { ref: 'feature/super-feature' } })),
+    mergePullRequest: sinon.stub().returns(Promise.resolve()),
+    deleteBranch: sinon.stub().returns(Promise.resolve()),
+  };
+};
+
+internals.mockSadGitService = () => {
+  return {
+    getPullRequest: sinon.stub().returns(Promise.reject(new Error('Mock error'))),
+    mergePullRequest: sinon.stub().returns(Promise.resolve()),
+    deleteBranch: sinon.stub().returns(Promise.resolve()),
+  };
+};
+
+internals.createMockProcess = () => {
+  return {
+    env: {
+      GITBOT_GITHUB_TOKEN: '123456789',
+    },
+  };
+};
+
+internals.createValidParams = () => {
+  return {
+    repo_owner: 'the_owner',
+    repo_name: 'repo_name',
+    pull_request_number: 8,
+  };
+};

--- a/test/git/git-service-test.js
+++ b/test/git/git-service-test.js
@@ -1,0 +1,155 @@
+const git_wrapper = require('../../src/git/git-service');
+
+describe('test/git/git-service-test.js', () => {
+  const github_token = '123456789';
+
+  describe('create', () => {
+
+    it('should return object with public functions', () => {
+      const git_service = git_wrapper.create(github_token);
+      git_service.should.have.keys([
+        'getPullRequest',
+        'mergePullRequest',
+        'deleteBranch',
+      ]);
+    });
+
+  });
+
+  describe('internals.getAuthenticatedGitHubClient', () => {
+
+    it('should use version 3 of the API', () => {
+      git_wrapper.internals.getAuthenticatedGitHubClient(github_token)
+          .should.have.property('version', '3.0.0');
+    });
+
+    it('should return a github client with auth set', () => {
+      git_wrapper.internals.getAuthenticatedGitHubClient(github_token).auth.should.eql({
+        type: 'token',
+        token: github_token,
+      });
+    });
+
+  });
+
+  describe('internals.getPullRequest', () => {
+    let github_service;
+
+    describe('when call goes well', () => {
+
+      beforeEach(() => {
+        github_service = {
+          pullRequests: {
+            get: sinon.stub().yieldsAsync(null, { url: 'https://api.github.com/repos/joe/test/pulls/4' }),
+          },
+        };
+      });
+
+      it('should resolve with pull request', () => {
+        return git_wrapper.internals.getPullRequest(github_service, '', '', 1)
+            .should
+            .be
+            .fulfilledWith({ url: 'https://api.github.com/repos/joe/test/pulls/4' });
+      });
+
+    });
+
+    describe('when call goes bad', () => {
+      let mock_err;
+
+      beforeEach(() => {
+        mock_err = new Error('Mock error');
+        github_service = {
+          pullRequests: {
+            get: sinon.stub().yieldsAsync(mock_err, null),
+          },
+        };
+      });
+
+      it('should reject with error', () => {
+        return git_wrapper.internals.getPullRequest(github_service, '', '', 1).should.be.rejectedWith(mock_err);
+      });
+
+    });
+
+  });
+
+  describe('internals.mergePullRequest', () => {
+    let github_service;
+
+    describe('when call goes well', () => {
+
+      beforeEach(() => {
+        github_service = {
+          pullRequests: {
+            merge: sinon.stub().yieldsAsync(null, { merged: true }),
+          },
+        };
+      });
+
+      it('should resolve with pull request', () => {
+        return git_wrapper.internals.mergePullRequest(github_service, '', '', 1).should.be.fulfilledWith({ merged: true });
+      });
+
+    });
+
+    describe('when call goes bad', () => {
+      let mock_err;
+
+      beforeEach(() => {
+        mock_err = new Error('Mock error');
+        github_service = {
+          pullRequests: {
+            merge: sinon.stub().yieldsAsync(mock_err, null),
+          },
+        };
+      });
+
+      it('should reject with error', () => {
+        return git_wrapper.internals.mergePullRequest(github_service, '', '', 1).should.be.rejectedWith(mock_err);
+      });
+
+    });
+
+  });
+
+  describe('internals.deleteBranch', () => {
+    let github_service;
+
+    describe('when call goes well', () => {
+
+      beforeEach(() => {
+        github_service = {
+          gitdata: {
+            deleteReference: sinon.stub().yieldsAsync(null, {}),
+          },
+        };
+      });
+
+      it('should resolve with pull request', () => {
+        return git_wrapper.internals.deleteBranch(github_service, '', '', '').should.be.fulfilledWith({});
+      });
+
+    });
+
+    describe('when call goes bad', () => {
+      let mock_err;
+
+      beforeEach(() => {
+        mock_err = new Error('Mock error');
+        github_service = {
+          gitdata: {
+            deleteReference: sinon.stub().yieldsAsync(mock_err, null),
+          },
+        };
+      });
+
+      it('should reject with error', () => {
+        return git_wrapper.internals.deleteBranch(github_service, '', '', '').should.be.rejectedWith(mock_err);
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
# gitbot

Module containing convenience scripts against GitHub

## Environment variables

- `GITBOT_GITHUB_TOKEN`: Access token against GitHub which needs to have read/write permissions on that repository

## Usage

Install module globally:

```
npm install -g @springworks/gitbot
```

```bash
  Usage: gitbot [options] [command]

  Commands:

    auto-merge   merge pull request and delete branch
    help [cmd]   display help for [cmd]

  Options:

    -h, --help  output usage information
```

### auto-merge
Merges pull request and deletes branch.

**Usage**
```
  Usage: gitbot-auto-merge [options]

  Options:

    -h, --help                 output usage information
    -O, --owner                repository owner
    -R, --repository-name      repository name
    -N, --pull-request-number  pull request number
```

**Example**

```
$ gitbot auto-merge -O john-doe -R awesome-repo -N 40
```

## Notes

This module uses the [semantic-release](https://github.com/semantic-release/semantic-release) automated package publishing. 
Which means that the commit messages are required to look in a certain [way](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md).

To ensure this pattern is enforced, we use [pre-git](https://github.com/bahmutov/pre-git) which installs a `commit-msg` hook.
Please read and understand what the `types` mean and use them properly when committing and contributing.

The `commit-msg` hook needs to know about your installed `node` which means that if you use third party application when committing, like [Tower](http://www.git-tower.com/), that application needs to know your PATH environment.
There are probably a lot of ways to solve this, but one that works is to open the application from the terminal: `open /Applications/Tower.app`.

## Contributing
1. Create new branch and commit changes with corresponding tests
2. Make a PR
3. :pray: :clap: