### PR TITLE
fix: change head querystring param

### DIFF
--- a/src/git/git-service.js
+++ b/src/git/git-service.js
@@ -43,7 +43,7 @@ internals.getPullRequest = (github, repo_owner, repo_name, pull_request_number) 
 };
 
 internals.getOpenPullRequestForSpecificBranch = (github, repo_owner, repo_name, branch_name) => {
-  const head = `${repo_owner}:refs/heads/${branch_name}`;
+  const head = `${repo_owner}:${branch_name}`;
   return new Promise((resolve, reject) => {
     github.pullRequests.getAll({
       owner: repo_owner,

--- a/test/git/git-service-test.js
+++ b/test/git/git-service-test.js
@@ -112,7 +112,7 @@ describe('test/git/git-service-test.js', () => {
           return git_wrapper.internals.getOpenPullRequestForSpecificBranch(github_service, 'the-owner', 'repo-name', 'my/feature')
               .then(() => {
                 github_service.pullRequests.getAll.firstCall.args[0].should.eql({
-                  head: 'the-owner:refs/heads/my/feature',
+                  head: 'the-owner:my/feature',
                   repo: 'repo-name',
                   state: 'open',
                   owner: 'the-owner',


### PR DESCRIPTION
fix: change head querystring param

Currently, the PRs are never found, because it seems like branches are no longer looked up using `refs/heads/`.